### PR TITLE
Make walk() method of _AD_group return non-user members

### DIFF
--- a/active_directory.py
+++ b/active_directory.py
@@ -1047,12 +1047,12 @@ class _AD_group(_AD_object):
     def walk(self):
         """Override the usual .walk method by returning instead:
 
-        group, groups, users
+        group, groups, items
         """
         members = self.member or []
         groups = [m for m in members if m.Class == 'group']
-        users = [m for m in members if m.Class == 'user']
-        yield(self, groups, users)
+        items = [m for m in members if m.Class != 'group']
+        yield(self, groups, items)
         for group in groups:
             for result in group.walk():
                 yield result


### PR DESCRIPTION
invoking walk() on an _AD_group object would work with user groups, but for computer groups it would not list members. The walk method was explicitly checking for a class of 'user' to find the non-subgroup members of a group. To fix it, I changed it to check that the class is not 'group'.
